### PR TITLE
Fix grid display orientation

### DIFF
--- a/Console.cs
+++ b/Console.cs
@@ -20,7 +20,7 @@ public static void PrintGrid(GameState gs)
     var sb = new StringBuilder();
 
     // Loop through rows (top to bottom) to display rows
-    for (int r = 0; r < gs.Rows; r++)
+    for (int r = gs.Rows - 1; r >= 0; r--)
     {
         // Loop through each column in the row
         for (int c = 0; c < gs.Cols; c++)


### PR DESCRIPTION
## Summary
- render grid rows from top to bottom so pieces appear to fall correctly

## Testing
- `dotnet run` *(fails: command not found)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68c697fccca88333bd68212ce8031768