### PR TITLE
Fix move validation and special disc effects

### DIFF
--- a/Parser.cs
+++ b/Parser.cs
@@ -28,10 +28,10 @@ namespace LineUp
             if (kind == DiscKind.Invalid) return false;
 
             // Validate column number
-            if (!int.TryParse(num, out int col1)) return false;   
-            if (col1 <= 0 || col1 > 7) return false;            
+            if (!int.TryParse(num, out int col1)) return false;
+            if (col1 <= 0) return false;
 
-            colIndex0 = col1 - 1;   
+            colIndex0 = col1 - 1;
             return true;
         }
     }


### PR DESCRIPTION
## Summary
- ensure magnetic discs operate on the selected column
- allow boring discs to clear even full columns
- remove hard-coded 7-column limit in move parser
- check both players for wins after any move
- keep turn with current player on invalid moves and support specials in test mode

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a07e6f488333a0d0c1ff20688460