### PR TITLE
Fix magnetic disc behaviour and display counts

### DIFF
--- a/Console.cs
+++ b/Console.cs
@@ -9,8 +9,8 @@ namespace LineUp
         {
             Console.WriteLine($"Mode: {gs.Mode} | Gird Size: {gs.Rows}x{gs.Cols} | WinLength: {gs.WinLength}");
             Console.WriteLine($"Turn: {(gs.CurrentTurn == PlayerId.P1 ? "P1" : "P2")}");
-            Console.WriteLine($"P1: @={gs.P1.OrdinaryCount}, B={gs.P1.BoringCount}, E={gs.P1.MagneticCount}");
-            Console.WriteLine($"P2: #={gs.P2.OrdinaryCount}, b={gs.P2.BoringCount}, e={gs.P2.MagneticCount}");
+            Console.WriteLine($"P1: @={gs.P1.OrdinaryCount}, B={gs.P1.BoringCount}, M={gs.P1.MagneticCount}");
+            Console.WriteLine($"P2: #={gs.P2.OrdinaryCount}, b={gs.P2.BoringCount}, m={gs.P2.MagneticCount}");
             Console.WriteLine();
         }
         public static void PrintGrid(GameState gs)


### PR DESCRIPTION
## Summary
- Correct magnetic disc mechanics and ensure it turns into ordinary disc
- Show disc placement messages and magnetic disc usage frames
- Display magnetic disc inventories with proper symbols

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ac2ad49883339c6d9192b488b63c